### PR TITLE
Only remove remote name on branch name parsing

### DIFF
--- a/rotten.js
+++ b/rotten.js
@@ -98,7 +98,7 @@ function main () {
         var deleteThese =
           inprod.map(function (info) {
             // take everything after the slash
-            var branchName = info.branch.replace(/(.*\/)/, '')
+            var branchName = info.branch.substr(info.branch.indexOf("/") + 1);
             return 'git push origin :' + branchName.red + '; git branch -D '
               + branchName.red + ';'
           })


### PR DESCRIPTION
Branch names can contain `/` characters, and rotten was stripping everything that was preceded by a `/` in the branch name. This wrongly parses a branch like `origin/feature/123-lorem-ipsum` into `123-lorem-ipsum`, which is wrong.
