### PR TITLE
Delete remote branches using full path

### DIFF
--- a/rotten.js
+++ b/rotten.js
@@ -102,7 +102,7 @@ function main () {
           inprod.map(function (info) {
             // take everything after the slash
             var branchName = info.branch.substr(info.branch.indexOf("/") + 1)
-            return 'git push origin :' + branchName.red + '; git branch -D '
+            return 'git push origin :refs/heads/' + branchName.red + '; git branch -D '
               + branchName.red + ';'
           })
           .join('\n')


### PR DESCRIPTION
Pushing to `:refs/heads/branch` instead of `:branch` avoids ambiguity (e.g. git won't know what to do if the local ref has already been deleted)
